### PR TITLE
Update config for bootsnap's cache

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ let
   gems = api.env;
   web = cfg.webPackage;
   env = {
+    BOOTSNAP_READONLY = "TRUE";
     DATABASE_URL = "postgresql://%2Frun%2Fpostgresql/accentor";
     FFMPEG_LOG_LOCATION = "/var/log/accentor/ffmpeg.log";
     FFMPEG_VERSION_LOCATION = "${cfg.home}/ffmpeg.version";

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,6 @@ let
   gems = api.env;
   web = cfg.webPackage;
   env = {
-    BOOTSNAP_CACHE_DIR = "/var/tmp/accentor/bootsnap";
     DATABASE_URL = "postgresql://%2Frun%2Fpostgresql/accentor";
     FFMPEG_LOG_LOCATION = "/var/log/accentor/ffmpeg.log";
     FFMPEG_VERSION_LOCATION = "${cfg.home}/ffmpeg.version";


### PR DESCRIPTION
This PR brings two improvements on top of accentor/api#398
* It removed the `BOOTSNAP_CACHE_DIR` as this isn't accurate anymore
* It opts into bootsnap's readonly mode (since the cache is stored in the nix stored, and bootsnap can't write to it). See accentor/api#396