### PR TITLE
Use systemd socket to reduce downtime during deploys

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -155,7 +155,7 @@ in
             "${gems}/bin/bundle exec rails db:migrate"
             "${gems}/bin/bundle exec rails ffmpeg:check_version"
           ];
-          ExecStart = "${gems}/bin/bundle exec --keep-file-descriptors puma -C ${api}/config/puma.rb";
+          ExecStart = "${gems}/bin/puma -C ${api}/config/puma.rb";
         };
       };
     } // (builtins.foldl' (x: y: x // y) { } (builtins.genList

--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ let
     FFMPEG_VERSION_LOCATION = "${cfg.home}/ffmpeg.version";
     PIDFILE = "/run/accentor/server.pid";
     STATEPATH = "/run/accentor/server.state";
-    SOCKETFILE = "unix:///run/accentor/server.sock";
+    SOCKETFILE = "unix:///run/accentor/server.socket";
     RACK_ENV = "production";
     RAILS_ENV = "production";
     RAILS_LOG_TO_STDOUT = "yes";
@@ -201,7 +201,7 @@ in
       accentor-api = {
         wantedBy = [ "sockets.target" ];
         wants = [ "accentor-api.service" ];
-        listenStreams = [ "3000" "/run/accentor/server.sock" ];
+        listenStreams = [ "3000" "/run/accentor/server.socket" ];
         socketConfig = {
           NoDelay = true;
           ReusePort = true;
@@ -221,7 +221,7 @@ in
     services.nginx.upstreams = mkIf (cfg.nginx != null) {
       "accentor_api_server" = {
         servers = {
-          "unix:///run/accentor/server.sock" = {};
+          "unix:///run/accentor/server.socket" = {};
           "localhost:3000" = {
             backup = true;
           };

--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,8 @@ let
     FFMPEG_LOG_LOCATION = "/var/log/accentor/ffmpeg.log";
     FFMPEG_VERSION_LOCATION = "${cfg.home}/ffmpeg.version";
     PIDFILE = "/run/accentor/server.pid";
+    STATEPATH = "/run/accentor/server.state";
+    SOCKETFILE = "unix:///run/accentor/server.sock";
     RACK_ENV = "production";
     RAILS_ENV = "production";
     RAILS_LOG_TO_STDOUT = "yes";

--- a/default.nix
+++ b/default.nix
@@ -201,10 +201,11 @@ in
       accentor-api = {
         wantedBy = [ "sockets.target" ];
         wants = [ "accentor-api.service" ];
-        listenStreams = [ "/run/accentor/server.socket" ];
+        listenStreams = [ "0.0.0.0:3000" "/run/accentor/server.socket" ];
         socketConfig = {
-          NoDelay = true;
           Backlog = 1024;
+          NoDelay = true;
+          ReusePort = true;
         };
       };
     };

--- a/default.nix
+++ b/default.nix
@@ -201,10 +201,9 @@ in
       accentor-api = {
         wantedBy = [ "sockets.target" ];
         wants = [ "accentor-api.service" ];
-        listenStreams = [ "3000" "/run/accentor/server.socket" ];
+        listenStreams = [ "/run/accentor/server.socket" ];
         socketConfig = {
           NoDelay = true;
-          ReusePort = true;
           Backlog = 1024;
         };
       };

--- a/default.nix
+++ b/default.nix
@@ -162,7 +162,7 @@ in
       (n: {
         "accentor-worker${toString n}" = {
           after = [ "network.target" "accentor-api.service" "postgresql.service" ];
-          requires = [ "accentor-api.service" "postgresql.service" ];
+          requires = [ "postgresql.service" ];
           wantedBy = [ "multi-user.target" ];
           environment = env;
           path = [ pkgs.ffmpeg gems gems.wrappedRuby ];

--- a/default.nix
+++ b/default.nix
@@ -155,7 +155,7 @@ in
             "${gems}/bin/bundle exec rails db:migrate"
             "${gems}/bin/bundle exec rails ffmpeg:check_version"
           ];
-          ExecStart = "${gems}/bin/bundle exec puma -C ${api}/config/puma.rb";
+          ExecStart = "${gems}/bin/bundle exec --keep-file-descriptors puma -C ${api}/config/puma.rb";
         };
       };
     } // (builtins.foldl' (x: y: x // y) { } (builtins.genList

--- a/default.nix
+++ b/default.nix
@@ -205,6 +205,17 @@ in
     };
     users.groups.accentor.gid = 314;
 
+    services.nginx.upstreams = mkIf (cfg.nginx != null) {
+      "accentor_api_server" = {
+        servers = {
+          "${env.SOCKETFILE}" = {};
+          "localhost:3000" = {
+            backup = true;
+          };
+        };
+      };
+    };
+
     services.nginx.virtualHosts = mkIf (cfg.nginx != null) {
       "${cfg.hostname}" = mkMerge [
         cfg.nginx
@@ -212,14 +223,14 @@ in
           root = web;
           locations = {
             "/api" = {
-              proxyPass = "http://localhost:3000";
+              proxyPass = "http://accentor_api_server";
               extraConfig = ''
                 proxy_set_header X-Forwarded-Ssl on;
                 client_max_body_size 40M;
               '';
             };
             "/rails" = {
-              proxyPass = "http://localhost:3000";
+              proxyPass = "http://accentor_api_server";
               extraConfig = ''
                 proxy_set_header X-Forwarded-Ssl on;
               '';


### PR DESCRIPTION
This PR brings a few changes, to decrease downtime during deploys.
* We add ENV variables to match accentor/api#402
* We create an upstream block in nginx, which tries the unix socket first and falls back to the tcp port.
* We create a systemd socket. This will make that both the socket file and the port are open when the service is starting. The socket config is taken from [puma's docs](https://github.com/puma/puma/blob/master/docs/systemd.md#socket-activation)

With these changes, we get (almost) downtime-less deploys. There is still a minor chance for downtime if nixos needs to restart a lot of services, but during most deploys, the user will simply be kept waiting during the boot time of rails.

