### PR TITLE
Only connect to puma through socket

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -222,9 +222,6 @@ in
       "accentor_api_server" = {
         servers = {
           "unix:///run/accentor/server.socket" = {};
-          "localhost:3000" = {
-            backup = true;
-          };
         };
       };
     };


### PR DESCRIPTION
Having both the socket and the port in our upstream block, means that nginx can/will try both of them, in case one of them is failing.

I learned the hard way that this can cause a server to spiral under heavy load: a timeout on the socket, will cause nginx to retry on the port. This means that puma/rails is getting the same request twice (and isn't aware that the first request is abandoned), meaning more threads will be used/blocked with the app doing the same work twice, meaning more requests will time out, meaning more retries, ...