### PR TITLE
Enable ruby YJIT

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,7 @@ let
     RAILS_LOG_TO_STDOUT = "yes";
     RAILS_STORAGE_PATH = "${cfg.home}/storage";
     RAILS_TRANSCODE_CACHE = "/var/tmp/accentor/transcode_cache";
+    RUBY_ENABLE_YJIT = "1";
   };
   exports = concatStringsSep
     "\n"


### PR DESCRIPTION
Depends on accentor/api#448

This PR enables ruby's YJIT, which _should_ give us some performance benefits and lower the memory footprint. I'm unsure whether this will actually make a difference, so would suggest trying this out for a few days/weeks, and see if this makes a difference.

I tested this locally, and did not but into any issues with a local server or running the tests.
