### PR TITLE
Update module to configure good job for background workers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,15 +61,14 @@ in
 
         The available options for queues are:
         * `*` (All queues)
-        * default
         * within_30_seconds
         * within_5_minutes
         * within_30_minutes
         * whenever
         Queues can be configured in different ways. Please check the good job docs for the possibilities: https://github.com/bensheldon/good_job#optimize-queues-threads-and-processes
       '';
-      default = [ "default,within_30_seconds" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
-      example = [ "default,within_30_seconds" "within_5_minutes:5;within_30_minutes:2;whenever:2" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
+      default = [ "within_30_seconds" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
+      example = [ "within_30_seconds" "within_5_minutes:5;within_30_minutes:2;whenever:2" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
       type = types.listOf types.str;
     };
 

--- a/default.nix
+++ b/default.nix
@@ -180,14 +180,14 @@ in
           ExecStart = "${gems}/bin/puma -C ${api}/config/puma.rb";
         };
       };
-    } // (builtins.foldl' (x: y: x // y) { } (builtins.genList
-      (index: {
+    } // (builtins.foldl' (x: y: x // y) { } (lib.lists.imap0
+      (index: value: {
         "accentor-worker-${toString (index)}" = {
           after = [ "network.target" "accentor-api.service" "postgresql.service" ];
           requires = [ "postgresql.service" ];
           wantedBy = [ "multi-user.target" ];
           environment = env // {
-            GOOD_JOB_QUEUES = (builtins.elemAt cfg.workers index);
+            GOOD_JOB_QUEUES = value;
           };
           path = [ pkgs.ffmpeg gems gems.wrappedRuby ];
           serviceConfig = {
@@ -200,8 +200,7 @@ in
             ExecStart = "${gems}/bin/bundle exec good_job start";
           };
         };
-      })
-      (builtins.length cfg.workers)))
+      })))
     // (builtins.foldl' (x: y: x // y) { } (builtins.genList
       (n: {
         "accentor-worker-delayed${toString n}" = {

--- a/default.nix
+++ b/default.nix
@@ -70,7 +70,7 @@ in
       '';
       default = [ "default,within_30_seconds" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
       example = [ "default,within_30_seconds" "within_5_minutes:5;within_30_minutes:2;whenever:2" "+default,within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
-      type = types.int;
+      type = types.listOf types.str;
     };
 
     delayedJobWorkers = mkOption {

--- a/default.nix
+++ b/default.nix
@@ -67,7 +67,7 @@ in
         * whenever
         Queues can be configured in different ways. Please check the good job docs for the possibilities: https://github.com/bensheldon/good_job#optimize-queues-threads-and-processes
       '';
-      default = [ "within_30_seconds" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
+      default = [ "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
       example = [ "within_30_seconds" "within_5_minutes:5;within_30_minutes:2;whenever:2" "+within_30_seconds,within_5_minutes,within_30_minutes,whenever" ];
       type = types.listOf types.str;
     };


### PR DESCRIPTION
This PR matches https://github.com/accentor/api/pull/478 and allows the user to configure both good job and delayed job. A next PR can remove the delayed job config.

I opted to have the user pass the names of queues instead of simply the amount of workers to allow more finegrained control.
The default still uses 4 workers (though now with 5 threads each). One of the workers is reserved for the most urgent items. The others will work off all queues in the order they are specified in the string.