### PR TITLE
Specify listenstream as ipv6

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -213,7 +213,7 @@ in
       accentor-api = {
         wantedBy = [ "sockets.target" ];
         wants = [ "accentor-api.service" ];
-        listenStreams = [ "0.0.0.0:3000" "/run/accentor/server.socket" ];
+        listenStreams = [ "[::]:3000" "/run/accentor/server.socket" ];
         socketConfig = {
           Backlog = 1024;
           NoDelay = true;


### PR DESCRIPTION
Since puma now listens to ipv6 by default ([see the upgrade guide](https://github.com/puma/puma/blob/main/docs/8.0-Upgrade.md#networking-and-performance)), this caused issue with our systemd socket.

What I think happens in puma 8:
* The socket binds to `0.0.0.0:3000`
* Puma boots and tries to bind to `[::]:3000`
* Puma notices that something already uses port 3000 (but not on ipv6) and crashes

I don't think this change is compatible with puma 7.x, since that doesn't bind to ipv6 by default (but I haven't tested it).
I was able to test this change in combination with puma 8.0 in [another application with a very similar setup](https://github.com/robbevp/feed-reader/pull/1069).